### PR TITLE
Fix docs, bug, and add initial tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ config = load_config("casual_mcp_config.json")
 ```
 
 #### `load_mcp_client`
-Creats a multi server FastMCP client from the config object
+Creates a multi server FastMCP client from the config object
 
 ```python
 from casual_mcp import load_mcp_client

--- a/mcp-servers/time-v2/server.py
+++ b/mcp-servers/time-v2/server.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from fastmcp import FastMCP
 from pydantic import Field
 import calendar
+import dateparser
 
 mcp = FastMCP("Time and Date 🚀")
 

--- a/src/casual_mcp/main.py
+++ b/src/casual_mcp/main.py
@@ -38,7 +38,7 @@ class GenerateRequest(BaseModel):
         default=None, title="Session to use"
     )
     model: str = Field(
-        title="Model to user"
+        title="Model to use"
     )
     system_prompt: str | None = Field(
         default=None, title="System Prompt to use"
@@ -50,7 +50,7 @@ class GenerateRequest(BaseModel):
 
 class ChatRequest(BaseModel):
     model: str = Field(
-        title="Model to user"
+        title="Model to use"
     )
     system_prompt: str | None = Field(
         default=None, title="System Prompt to use"

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,84 @@
+import json
+import pytest
+
+from casual_mcp.mcp_tool_chat import McpToolChat
+from casual_mcp.providers.abstract_provider import CasualMcpProvider
+from casual_mcp.models.messages import AssistantMessage
+from casual_mcp.models.tool_call import AssistantToolCall, AssistantToolCallFunction
+
+class DummyTool:
+    def __init__(self, name):
+        self.name = name
+
+
+class DummyResult:
+    def __init__(self, text):
+        self.text = text
+
+
+class DummyClient:
+    def __init__(self):
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def list_tools(self):
+        return [DummyTool("echo")]
+
+    async def call_tool(self, name, args):
+        self.calls.append((name, args))
+        return [DummyResult(text=args.get("text", ""))]
+
+class DummyProvider(CasualMcpProvider):
+    async def generate(self, messages, tools):
+        return AssistantMessage(content="ok", tool_calls=None)
+
+
+class ToolCallingProvider(CasualMcpProvider):
+    def __init__(self):
+        self.calls = 0
+
+    async def generate(self, messages, tools):
+        self.calls += 1
+        if self.calls == 1:
+            return AssistantMessage(
+                content=None,
+                tool_calls=[
+                    AssistantToolCall(
+                        id="1",
+                        function=AssistantToolCallFunction(
+                            name=tools[0].name,
+                            arguments=json.dumps({"text": "hello"}),
+                        ),
+                    )
+                ],
+            )
+        else:
+            return AssistantMessage(content="done", tool_calls=None)
+
+@pytest.mark.asyncio
+async def test_generate_stores_session():
+    chat = McpToolChat(DummyClient(), DummyProvider(), "sys")
+    result = await chat.generate("hi", session_id="sess1")
+    assert result[-1].content == "ok"
+    session = McpToolChat.get_session("sess1")
+    assert session is not None
+    assert len(session) == 2
+
+
+@pytest.mark.asyncio
+async def test_tool_calling():
+    client = DummyClient()
+    provider = ToolCallingProvider()
+    chat = McpToolChat(client, provider, "sys")
+    messages = await chat.generate("hi")
+
+    assert provider.calls == 2
+    assert client.calls == [("echo", {"text": "hello"})]
+    tool_results = [m for m in messages if getattr(m, "role", "") == "tool"]
+    assert len(tool_results) == 1
+    assert tool_results[0].content == "hello"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+import json
+import pytest
+
+from casual_mcp.models.tool_call import AssistantToolCall, AssistantToolCallFunction
+from casual_mcp.utils import format_tool_call_result
+
+@pytest.fixture
+def tool_call():
+    return AssistantToolCall(
+        id="abc123",
+        function=AssistantToolCallFunction(name="echo", arguments=json.dumps({"text": "hi"}))
+    )
+
+def test_format_result_style_result(tool_call):
+    assert format_tool_call_result(tool_call, "hello", style="result") == "hello"
+
+
+def test_format_result_style_function_result(tool_call):
+    assert format_tool_call_result(tool_call, "hello", style="function_result") == "echo → hello"
+
+
+def test_format_result_style_function_args_result(tool_call):
+    expected = "echo(text='hi') → hello"
+    assert format_tool_call_result(tool_call, "hello", style="function_args_result") == expected
+
+
+def test_format_result_include_id(tool_call):
+    formatted = format_tool_call_result(tool_call, "hello", style="result", include_id=True)
+    assert formatted.startswith("ID: abc123")


### PR DESCRIPTION
## Summary
- fix typo in README
- import `dateparser` in time server
- correct "Model to use" titles
- add tests for utils and chat classes
- extend McpToolChat tests to cover tool calls

## Testing
- `PYTHONPATH=./src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430a48e54483299b998c0035510469