### PR TITLE
fix: keep MCP server connections alive and add multiturn example

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,12 @@ from casual_llm import SystemMessage, UserMessage
 from casual_mcp import McpToolChat, load_config
 
 config = load_config("casual_mcp_config.json")
-chat = McpToolChat.from_config(config)
-
-messages = [
-    SystemMessage(content="You are a helpful assistant."),
-    UserMessage(content="What time is it?")
-]
-response = await chat.chat(messages, model="gpt-4.1")
+async with McpToolChat.from_config(config) as chat:
+    messages = [
+        SystemMessage(content="You are a helpful assistant."),
+        UserMessage(content="What time is it?")
+    ]
+    response = await chat.chat(messages, model="gpt-4.1")
 ```
 
 For full control you can still construct `McpToolChat` manually — see the [Programmatic Usage Guide](docs/programmatic-usage.md) for details on `from_config()`, model selection at call time, usage statistics, toolsets, and common patterns.

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ Core tool-calling examples using `McpToolChat.from_config()`.
 |--------|-------------|
 | `chat_weather.py` | Asks the LLM to compare weather in two cities using weather tools |
 | `chat_fetch.py` | Asks the LLM to fetch and summarise a webpage |
+| `multiturn.py` | Multi-turn conversation that asks about Sydney's weather then compares it to Tokyo, demonstrating persistent connections and per-turn stats |
 | `manual_construction.py` | Builds `McpToolChat` manually from individual components (`ToolCache`, `ModelFactory`, `load_mcp_client`) instead of using `from_config()` |
 
 ### [tool_discovery/](tool_discovery/)

--- a/examples/tool_calling/chat_weather.py
+++ b/examples/tool_calling/chat_weather.py
@@ -29,33 +29,37 @@ async def main():
             print(f"  - {name}")
         return
 
-    chat = McpToolChat.from_config(config)
+    async with McpToolChat.from_config(config) as chat:
+        print(f"Model: {MODEL_NAME}")
 
-    print(f"Model: {MODEL_NAME}")
+        # Build messages manually for full control
+        messages = [
+            SystemMessage(
+                content="You are a weather expert. Use the weather tools to get accurate data."
+            ),
+            UserMessage(content="Compare the weather in Tokyo and Sydney"),
+        ]
 
-    # Build messages manually for full control
-    messages = [
-        SystemMessage(
-            content="You are a weather expert. Use the weather tools to get accurate data."
-        ),
-        UserMessage(content="Compare the weather in Tokyo and Sydney"),
-    ]
+        print("\nUser: Compare the weather in Tokyo and Sydney\n")
 
-    print("\nUser: Compare the weather in Tokyo and Sydney\n")
+        response_messages = await chat.chat(messages, model=MODEL_NAME)
 
-    response_messages = await chat.chat(messages, model=MODEL_NAME)
+        tool_count = sum(1 for m in response_messages if m.role == "tool")
+        print(f"\nResponse: {len(response_messages)} messages, {tool_count} tool results")
 
-    tool_count = sum(1 for m in response_messages if m.role == "tool")
-    print(f"\nResponse: {len(response_messages)} messages, {tool_count} tool results")
-
-    for msg in reversed(response_messages):
-        if msg.role == "assistant" and msg.content:
-            print(f"\nFinal: {msg.content}")
-            break
-
-    # Clean up MCP client connections
-    await chat.mcp_client.close()
+        for msg in reversed(response_messages):
+            if msg.role == "assistant" and msg.content:
+                print(f"\nFinal: {msg.content}")
+                break
 
 
 if __name__ == "__main__":
+    # Python <3.12: subprocess transport __del__ fires after the event loop
+    # closes, producing harmless "Event loop is closed" RuntimeErrors.
+    import sys
+
+    _orig_hook = sys.unraisablehook
+    sys.unraisablehook = lambda u: (
+        None if "Event loop is closed" in str(u.exc_value) else _orig_hook(u)
+    )
     asyncio.run(main())

--- a/examples/tool_calling/multiturn.py
+++ b/examples/tool_calling/multiturn.py
@@ -74,8 +74,12 @@ async def main():
         if turn1_stats and turn2_stats:
             total_tool_calls = turn1_stats.tool_calls.total + turn2_stats.tool_calls.total
             total_llm_calls = turn1_stats.llm_calls + turn2_stats.llm_calls
-            print(f"Turn 1: {turn1_stats.tool_calls.total} tool calls, {turn1_stats.llm_calls} LLM calls")
-            print(f"Turn 2: {turn2_stats.tool_calls.total} tool calls, {turn2_stats.llm_calls} LLM calls")
+            print(
+                f"Turn 1: {turn1_stats.tool_calls.total} tool calls, {turn1_stats.llm_calls} LLM calls"
+            )
+            print(
+                f"Turn 2: {turn2_stats.tool_calls.total} tool calls, {turn2_stats.llm_calls} LLM calls"
+            )
             print(f"Total:  {total_tool_calls} tool calls, {total_llm_calls} LLM calls")
 
 

--- a/examples/tool_calling/multiturn.py
+++ b/examples/tool_calling/multiturn.py
@@ -1,0 +1,91 @@
+"""
+Example: Multi-turn conversation with persistent connection.
+
+Demonstrates managing message history across multiple turns while
+keeping the MCP connection alive using `async with`.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from casual_llm import UserMessage, SystemMessage
+
+from casual_mcp import McpToolChat, load_config
+from casual_mcp.logging import configure_logging
+
+load_dotenv()
+configure_logging(level=os.getenv("LOG_LEVEL", "WARNING"))  # type: ignore
+
+MODEL_NAME = os.getenv("MODEL_NAME", "gpt-4.1-nano")
+
+
+async def main():
+    config = load_config("config.json")
+
+    if MODEL_NAME not in config.models:
+        print(f"Model '{MODEL_NAME}' not found in config. Available models:")
+        for name in config.models:
+            print(f"  - {name}")
+        return
+
+    async with McpToolChat.from_config(config) as chat:
+        print(f"Model: {MODEL_NAME}\n")
+
+        messages = [
+            SystemMessage(
+                content="You are a weather expert. Use the weather tools to get accurate data."
+            ),
+        ]
+
+        # Turn 1
+        user_input = "What is the weather in Sydney?"
+        print(f"User: {user_input}")
+        messages.append(UserMessage(content=user_input))
+
+        response_messages = await chat.chat(messages, model=MODEL_NAME)
+        messages.extend(response_messages)
+
+        for msg in reversed(response_messages):
+            if msg.role == "assistant" and msg.content:
+                print(f"Assistant: {msg.content}\n")
+                break
+
+        # Stats are per-call, so capture after each turn
+        turn1_stats = chat.get_stats()
+
+        # Turn 2
+        user_input = "How does it compare to Tokyo?"
+        print(f"User: {user_input}")
+        messages.append(UserMessage(content=user_input))
+
+        response_messages = await chat.chat(messages, model=MODEL_NAME)
+        messages.extend(response_messages)
+
+        for msg in reversed(response_messages):
+            if msg.role == "assistant" and msg.content:
+                print(f"Assistant: {msg.content}\n")
+                break
+
+        turn2_stats = chat.get_stats()
+
+        # Show per-turn and total stats
+        if turn1_stats and turn2_stats:
+            total_tool_calls = turn1_stats.tool_calls.total + turn2_stats.tool_calls.total
+            total_llm_calls = turn1_stats.llm_calls + turn2_stats.llm_calls
+            print(f"Turn 1: {turn1_stats.tool_calls.total} tool calls, {turn1_stats.llm_calls} LLM calls")
+            print(f"Turn 2: {turn2_stats.tool_calls.total} tool calls, {turn2_stats.llm_calls} LLM calls")
+            print(f"Total:  {total_tool_calls} tool calls, {total_llm_calls} LLM calls")
+
+
+if __name__ == "__main__":
+    # Python <3.12: subprocess transport __del__ fires after the event loop
+    # closes, producing harmless "Event loop is closed" RuntimeErrors.
+    import sys
+
+    _orig_hook = sys.unraisablehook
+    sys.unraisablehook = lambda u: (
+        None if "Event loop is closed" in str(u.exc_value) else _orig_hook(u)
+    )
+    asyncio.run(main())

--- a/examples/tool_discovery/multi_server_discovery.py
+++ b/examples/tool_discovery/multi_server_discovery.py
@@ -35,58 +35,71 @@ async def main():
             print(f"  - {name}")
         return
 
-    chat = McpToolChat.from_config(config)
+    async with McpToolChat.from_config(config) as chat:
+        print(f"Model: {MODEL_NAME}")
 
-    print(f"Model: {MODEL_NAME}")
+        # This prompt requires tools from two different servers:
+        #   - weather server: current_weather / forecast
+        #   - time server: next_weekday / current_time
+        messages = [
+            SystemMessage(
+                content=(
+                    "You are a helpful assistant. Use the available tools to answer "
+                    "the user's question accurately."
+                )
+            ),
+            UserMessage(
+                content=(
+                    "I'm planning a weekend trip to Tokyo. "
+                    "What date is next Saturday, and what's the weather forecast for Tokyo "
+                    "that day?"
+                )
+            ),
+        ]
 
-    # This prompt requires tools from two different servers:
-    #   - weather server: current_weather / forecast
-    #   - time server: next_weekday / current_time
-    messages = [
-        SystemMessage(
-            content=(
-                "You are a helpful assistant. Use the available tools to answer "
-                "the user's question accurately."
-            )
-        ),
-        UserMessage(
-            content=(
-                "I'm planning a weekend trip to Tokyo. "
-                "What date is next Saturday, and what's the weather forecast for Tokyo that day?"
-            )
-        ),
-    ]
+        print("\nUser: I'm planning a weekend trip to Tokyo.")
+        print(
+            "      What date is next Saturday, and what's the weather forecast for Tokyo "
+            "that day?"
+        )
+        print(
+            "\n(The LLM needs to discover tools from both the 'time' and 'weather' servers)\n"
+        )
 
-    print("\nUser: I'm planning a weekend trip to Tokyo.")
-    print("      What date is next Saturday, and what's the weather forecast for Tokyo that day?")
-    print("\n(The LLM needs to discover tools from both the 'time' and 'weather' servers)\n")
+        response_messages = await chat.chat(messages, model=MODEL_NAME)
 
-    response_messages = await chat.chat(messages, model=MODEL_NAME)
+        # Show the conversation flow
+        for msg in response_messages:
+            if msg.role == "assistant":
+                if hasattr(msg, "tool_calls") and msg.tool_calls:
+                    for tc in msg.tool_calls:
+                        print(f"  Tool call: {tc.function.name}({tc.function.arguments})")
+                if msg.content:
+                    print(f"\nAssistant: {msg.content}")
+            elif msg.role == "tool":
+                content = msg.content[:200] + "..." if len(msg.content) > 200 else msg.content
+                print(f"  Tool result ({msg.name}): {content}")
 
-    # Show the conversation flow
-    for msg in response_messages:
-        if msg.role == "assistant":
-            if hasattr(msg, "tool_calls") and msg.tool_calls:
-                for tc in msg.tool_calls:
-                    print(f"  Tool call: {tc.function.name}({tc.function.arguments})")
-            if msg.content:
-                print(f"\nAssistant: {msg.content}")
-        elif msg.role == "tool":
-            content = msg.content[:200] + "..." if len(msg.content) > 200 else msg.content
-            print(f"  Tool result ({msg.name}): {content}")
-
-    # Show discovery stats
-    stats = chat.get_stats()
-    if stats:
-        print(f"\nStats: {stats.llm_calls} LLM calls, {stats.tool_calls.total} tool calls")
-        if stats.discovery:
+        # Show discovery stats
+        stats = chat.get_stats()
+        if stats:
             print(
-                f"Discovery: {stats.discovery.search_calls} search calls, "
-                f"{stats.discovery.tools_discovered} tools discovered"
+                f"\nStats: {stats.llm_calls} LLM calls, {stats.tool_calls.total} tool calls"
             )
-
-    await chat.mcp_client.close()
+            if stats.discovery:
+                print(
+                    f"Discovery: {stats.discovery.search_calls} search calls, "
+                    f"{stats.discovery.tools_discovered} tools discovered"
+                )
 
 
 if __name__ == "__main__":
+    # Python <3.12: subprocess transport __del__ fires after the event loop
+    # closes, producing harmless "Event loop is closed" RuntimeErrors.
+    import sys
+
+    _orig_hook = sys.unraisablehook
+    sys.unraisablehook = lambda u: (
+        None if "Event loop is closed" in str(u.exc_value) else _orig_hook(u)
+    )
     asyncio.run(main())

--- a/examples/tool_discovery/multi_server_discovery.py
+++ b/examples/tool_discovery/multi_server_discovery.py
@@ -59,12 +59,9 @@ async def main():
 
         print("\nUser: I'm planning a weekend trip to Tokyo.")
         print(
-            "      What date is next Saturday, and what's the weather forecast for Tokyo "
-            "that day?"
+            "      What date is next Saturday, and what's the weather forecast for Tokyo that day?"
         )
-        print(
-            "\n(The LLM needs to discover tools from both the 'time' and 'weather' servers)\n"
-        )
+        print("\n(The LLM needs to discover tools from both the 'time' and 'weather' servers)\n")
 
         response_messages = await chat.chat(messages, model=MODEL_NAME)
 
@@ -83,9 +80,7 @@ async def main():
         # Show discovery stats
         stats = chat.get_stats()
         if stats:
-            print(
-                f"\nStats: {stats.llm_calls} LLM calls, {stats.tool_calls.total} tool calls"
-            )
+            print(f"\nStats: {stats.llm_calls} LLM calls, {stats.tool_calls.total} tool calls")
             if stats.discovery:
                 print(
                     f"Discovery: {stats.discovery.search_calls} search calls, "

--- a/examples/tool_sets/chat_with_toolset.py
+++ b/examples/tool_sets/chat_with_toolset.py
@@ -79,10 +79,7 @@ async def main():
             # Show stats
             stats = chat.get_stats()
             if stats:
-                print(
-                    f"\nStats: {stats.tool_calls.total} tool calls, "
-                    f"{stats.llm_calls} LLM calls"
-                )
+                print(f"\nStats: {stats.tool_calls.total} tool calls, {stats.llm_calls} LLM calls")
         else:
             print("Note: 'math' server not configured, skipping programmatic toolset example")
 

--- a/src/casual_mcp/main.py
+++ b/src/casual_mcp/main.py
@@ -51,9 +51,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Initialise shared resources on startup; clean up on shutdown."""
     state.config = load_config("casual_mcp_config.json")
     state.chat_instance = McpToolChat.from_config(state.config, system=default_system_prompt)
-    logger.info("Application started")
-    yield
-    logger.info("Application shut down")
+    async with state.chat_instance:
+        logger.info("Application started")
+        yield
+        logger.info("Application shut down")
 
 
 app = FastAPI(lifespan=lifespan)

--- a/tests/test_mcp_tool_chat.py
+++ b/tests/test_mcp_tool_chat.py
@@ -798,6 +798,24 @@ class TestMalformedToolArguments:
         assert result.tool_call_id == "call_1"
 
 
+class TestMcpToolChatContextManager:
+    """Tests for McpToolChat async context manager."""
+
+    async def test_aenter_connects_and_aexit_disconnects(self):
+        """async with McpToolChat should connect/disconnect the MCP client."""
+        client = AsyncMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+
+        chat = McpToolChat(client, "System")
+
+        async with chat as returned:
+            assert returned is chat
+            client.__aenter__.assert_called_once()
+
+        client.__aexit__.assert_called_once()
+
+
 class TestConcurrentRequests:
     """Test that concurrent chat() calls don't corrupt each other's stats."""
 


### PR DESCRIPTION
## Summary
- Keep FastMCP client connection alive to avoid reconnecting to MCP servers on each `chat()` call. The connection lifecycle is now managed via `async with` context manager, with `chat()` reusing the existing session through re-entrant reference counting.
- Add a multiturn chat example demonstrating conversation history management with persistent connections.

## Test plan
- [ ] Verify persistent connections work with `async with McpToolChat.from_config(config) as chat:`
- [ ] Verify per-call connections still work without context manager
- [ ] Run existing test suite: `uv run pytest tests/`
- [ ] Test multiturn example runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)